### PR TITLE
Optimizations of OxideMode CallHook

### DIFF
--- a/src/Oxide/OxideMod.cs
+++ b/src/Oxide/OxideMod.cs
@@ -247,28 +247,109 @@ public class OxideMod
 		return HookCaller.CallStaticHook(hookId, args);
 	}
 
+	public object CallDeprecatedHook(string oldHook, string newHook, DateTime expireDate)
+	{
+	    var oldHookId = HookStringPool.GetOrAdd(oldHook);
+	    var newHookId = HookStringPool.GetOrAdd(newHook);
+	    return HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate);
+	}
+
+	public object CallDeprecatedHook(string oldHook, string newHook, DateTime expireDate, object arg1)
+	{
+	    var oldHookId = HookStringPool.GetOrAdd(oldHook);
+	    var newHookId = HookStringPool.GetOrAdd(newHook);
+	    return HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, arg1);
+	}
+
+	public object CallDeprecatedHook(string oldHook, string newHook, DateTime expireDate, object arg1, object arg2)
+	{
+	    var oldHookId = HookStringPool.GetOrAdd(oldHook);
+	    var newHookId = HookStringPool.GetOrAdd(newHook);
+	    return HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, arg1, arg2);
+	}
+
+	public object CallDeprecatedHook(string oldHook, string newHook, DateTime expireDate, object arg1, object arg2, object arg3)
+	{
+	    var oldHookId = HookStringPool.GetOrAdd(oldHook);
+	    var newHookId = HookStringPool.GetOrAdd(newHook);
+	    return HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, arg1, arg2, arg3);
+	}
+
+	public object CallDeprecatedHook(string oldHook, string newHook, DateTime expireDate, object arg1, object arg2, object arg3, object arg4)
+	{
+	    var oldHookId = HookStringPool.GetOrAdd(oldHook);
+	    var newHookId = HookStringPool.GetOrAdd(newHook);
+	    return HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, arg1, arg2, arg3, arg4);
+	}
+
+	public object CallDeprecatedHook(string oldHook, string newHook, DateTime expireDate, object arg1, object arg2, object arg3, object arg4, object arg5)
+	{
+	    var oldHookId = HookStringPool.GetOrAdd(oldHook);
+	    var newHookId = HookStringPool.GetOrAdd(newHook);
+	    return HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, arg1, arg2, arg3, arg4, arg5);
+	}
+
+	public object CallDeprecatedHook(string oldHook, string newHook, DateTime expireDate, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6)
+	{
+	    var oldHookId = HookStringPool.GetOrAdd(oldHook);
+	    var newHookId = HookStringPool.GetOrAdd(newHook);
+	    return HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, arg1, arg2, arg3, arg4, arg5, arg6);
+	}
+
+	public object CallDeprecatedHook(string oldHook, string newHook, DateTime expireDate, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7)
+	{
+	    var oldHookId = HookStringPool.GetOrAdd(oldHook);
+	    var newHookId = HookStringPool.GetOrAdd(newHook);
+	    return HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+	}
+
+	public object CallDeprecatedHook(string oldHook, string newHook, DateTime expireDate, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8)
+	{
+	    var oldHookId = HookStringPool.GetOrAdd(oldHook);
+	    var newHookId = HookStringPool.GetOrAdd(newHook);
+	    return HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+	}
+
+	public object CallDeprecatedHook(string oldHook, string newHook, DateTime expireDate, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8, object arg9)
+	{
+	    var oldHookId = HookStringPool.GetOrAdd(oldHook);
+	    var newHookId = HookStringPool.GetOrAdd(newHook);
+	    return HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+	}
+
+	public object CallDeprecatedHook(string oldHook, string newHook, DateTime expireDate, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8, object arg9, object arg10)
+	{
+	    var oldHookId = HookStringPool.GetOrAdd(oldHook);
+	    var newHookId = HookStringPool.GetOrAdd(newHook);
+	    return HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+	}
+
+	public object CallDeprecatedHook(string oldHook, string newHook, DateTime expireDate, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8, object arg9, object arg10, object arg11)
+	{
+	    var oldHookId = HookStringPool.GetOrAdd(oldHook);
+	    var newHookId = HookStringPool.GetOrAdd(newHook);
+	    return HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
+	}
+
+	public object CallDeprecatedHook(string oldHook, string newHook, DateTime expireDate, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8, object arg9, object arg10, object arg11, object arg12)
+	{
+	    var oldHookId = HookStringPool.GetOrAdd(oldHook);
+	    var newHookId = HookStringPool.GetOrAdd(newHook);
+	    return HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
+	}
+
+	public object CallDeprecatedHook(string oldHook, string newHook, DateTime expireDate, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8, object arg9, object arg10, object arg11, object arg12, object arg13)
+	{
+	    var oldHookId = HookStringPool.GetOrAdd(oldHook);
+	    var newHookId = HookStringPool.GetOrAdd(newHook);
+	    return HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
+	}
+
 	public object CallDeprecatedHook(string oldHook, string newHook, DateTime expireDate, params object[] args)
 	{
 		var oldHookId = HookStringPool.GetOrAdd(oldHook);
 		var newHookId = HookStringPool.GetOrAdd(newHook);
-
-		return args.Length switch
-		{
-			1 => HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, args[0]),
-			2 => HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, args[0], args[1]),
-			3 => HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, args[0], args[1], args[2]),
-			4 => HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, args[0], args[1], args[2], args[3]),
-			5 => HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, args[0], args[1], args[2], args[3], args[4]),
-			6 => HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, args[0], args[1], args[2], args[3], args[4], args[5]),
-			7 => HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, args[0], args[1], args[2], args[3], args[4], args[5], args[6]),
-			8 => HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]),
-			9 => HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]),
-			10 => HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9]),
-			11 => HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10]),
-			12 => HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11]),
-			13 => HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12]),
-			_ => HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate)
-		};
+		return HookCaller.CallStaticDeprecatedHook(oldHookId, newHookId, expireDate, args);
 	}
 
 	internal static ConcurrentDictionary<string, object> _libraryCache = new();

--- a/src/Oxide/OxideMod.cs
+++ b/src/Oxide/OxideMod.cs
@@ -157,27 +157,94 @@ public class OxideMod
 		return _extensions;
 	}
 
+	public object CallHook(string hookName)
+	{
+		var hookId = HookStringPool.GetOrAdd(hookName);
+		return HookCaller.CallStaticHook(hookId);
+	}
+
+	public object CallHook(string hookName, object arg1)
+	{
+	    var hookId = HookStringPool.GetOrAdd(hookName);
+	    return HookCaller.CallStaticHook(hookId, arg1);
+	}
+
+	public object CallHook(string hookName, object arg1, object arg2)
+	{
+	    var hookId = HookStringPool.GetOrAdd(hookName);
+	    return HookCaller.CallStaticHook(hookId, arg1, arg2);
+	}
+
+	public object CallHook(string hookName, object arg1, object arg2, object arg3)
+	{
+	    var hookId = HookStringPool.GetOrAdd(hookName);
+	    return HookCaller.CallStaticHook(hookId, arg1, arg2, arg3);
+	}
+
+	public object CallHook(string hookName, object arg1, object arg2, object arg3, object arg4)
+	{
+	    var hookId = HookStringPool.GetOrAdd(hookName);
+	    return HookCaller.CallStaticHook(hookId, arg1, arg2, arg3, arg4);
+	}
+
+	public object CallHook(string hookName, object arg1, object arg2, object arg3, object arg4, object arg5)
+	{
+	    var hookId = HookStringPool.GetOrAdd(hookName);
+	    return HookCaller.CallStaticHook(hookId, arg1, arg2, arg3, arg4, arg5);
+	}
+
+	public object CallHook(string hookName, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6)
+	{
+	    var hookId = HookStringPool.GetOrAdd(hookName);
+	    return HookCaller.CallStaticHook(hookId, arg1, arg2, arg3, arg4, arg5, arg6);
+	}
+
+	public object CallHook(string hookName, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7)
+	{
+	    var hookId = HookStringPool.GetOrAdd(hookName);
+	    return HookCaller.CallStaticHook(hookId, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+	}
+
+	public object CallHook(string hookName, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8)
+	{
+	    var hookId = HookStringPool.GetOrAdd(hookName);
+	    return HookCaller.CallStaticHook(hookId, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+	}
+
+	public object CallHook(string hookName, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8, object arg9)
+	{
+	    var hookId = HookStringPool.GetOrAdd(hookName);
+	    return HookCaller.CallStaticHook(hookId, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+	}
+
+	public object CallHook(string hookName, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8, object arg9, object arg10)
+	{
+	    var hookId = HookStringPool.GetOrAdd(hookName);
+	    return HookCaller.CallStaticHook(hookId, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+	}
+
+	public object CallHook(string hookName, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8, object arg9, object arg10, object arg11)
+	{
+	    var hookId = HookStringPool.GetOrAdd(hookName);
+	    return HookCaller.CallStaticHook(hookId, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
+	}
+
+	public object CallHook(string hookName, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8, object arg9, object arg10, object arg11, object arg12)
+	{
+	    var hookId = HookStringPool.GetOrAdd(hookName);
+	    return HookCaller.CallStaticHook(hookId, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
+	}
+
+	public object CallHook(string hookName, object arg1, object arg2, object arg3, object arg4, object arg5, object arg6, object arg7, object arg8, object arg9, object arg10, object arg11, object arg12, object arg13)
+	{
+	    var hookId = HookStringPool.GetOrAdd(hookName);
+	    return HookCaller.CallStaticHook(hookId, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
+	}
+
 	public object CallHook(string hookName, params object[] args)
 	{
 		var hookId = HookStringPool.GetOrAdd(hookName);
-
-		return args?.Length switch
-		{
-			1 => HookCaller.CallStaticHook(hookId, args[0]),
-			2 => HookCaller.CallStaticHook(hookId, args[0], args[1]),
-			3 => HookCaller.CallStaticHook(hookId, args[0], args[1], args[2]),
-			4 => HookCaller.CallStaticHook(hookId, args[0], args[1], args[2], args[3]),
-			5 => HookCaller.CallStaticHook(hookId, args[0], args[1], args[2], args[3], args[4]),
-			6 => HookCaller.CallStaticHook(hookId, args[0], args[1], args[2], args[3], args[4], args[5]),
-			7 => HookCaller.CallStaticHook(hookId, args[0], args[1], args[2], args[3], args[4], args[5], args[6]),
-			8 => HookCaller.CallStaticHook(hookId, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]),
-			9 => HookCaller.CallStaticHook(hookId, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]),
-			10 => HookCaller.CallStaticHook(hookId, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9]),
-			11 => HookCaller.CallStaticHook(hookId, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10]),
-			12 => HookCaller.CallStaticHook(hookId, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11]),
-			13 => HookCaller.CallStaticHook(hookId, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12]),
-			_ => HookCaller.CallStaticHook(hookId, args, true)
-		};
+		return HookCaller.CallStaticHook(hookId, args);
 	}
 
 	public object CallDeprecatedHook(string oldHook, string newHook, DateTime expireDate, params object[] args)


### PR DESCRIPTION
I've noticed that even if oxide hooks are not used anywhere, call to them allocates memory and increase load on garbage collector.
Turned out we always allocated array of arguments because we didn't have other implementations to pass them as separate arguments.
This PR fixes this issue and also fixes bug in case there were more than 13 arguments.