### PR TITLE
Dropdown Support for Plugin Configs

### DIFF
--- a/src/Carbon/Modules/AdminModule/AdminModule.Tab.cs
+++ b/src/Carbon/Modules/AdminModule/AdminModule.Tab.cs
@@ -327,7 +327,7 @@ public partial class AdminModule
 				}
 			}
 		}
-		public void Dispose()
+		public virtual void Dispose()
 		{
 			foreach (var column in Columns)
 			{

--- a/src/Carbon/Modules/AdminModule/AdminModule.Tabs.ConfigEditor.cs
+++ b/src/Carbon/Modules/AdminModule/AdminModule.Tabs.ConfigEditor.cs
@@ -67,14 +67,32 @@ public partial class AdminModule
 
 						if (baseToken != null)
 						{
-							LegendOptions[token.Key] = [.. legendObj.Properties().Select(p => p.Name)];
+							var legendProperties = Facepunch.Pool.Get<List<JProperty>>();
+							legendProperties.AddRange(legendObj.Properties());
 
-							var baseTokenValue = baseToken.ToString();
-							var defaultValue = legendObj.Properties()
-								.FirstOrDefault(p => p.Name == baseTokenValue)
-								?? legendObj.Properties().First();
+							LegendOptions[token.Key] = [.. legendProperties.Select(p => p.Name)];
 
-							LegendIndex[token.Key] = legendObj.Properties().IndexOf(defaultValue);
+							int defaultSelectedIndex = 0;
+							if (baseToken.Type != JTokenType.Null)
+							{
+								var baseTokenValue = baseToken.ToString();
+								foreach (var prop in legendProperties)
+								{
+									if (prop.Value.ToString() == baseTokenValue)
+										break;
+
+									defaultSelectedIndex++;
+								}
+							}
+
+							if (defaultSelectedIndex >= legendProperties.Count)
+							{
+								defaultSelectedIndex = 0;
+							}
+
+							LegendIndex[token.Key] = defaultSelectedIndex;
+
+							Facepunch.Pool.FreeUnmanaged(ref legendProperties);
 
 							continue;
 						}

--- a/src/Carbon/Modules/AdminModule/AdminModule.Tabs.ConfigEditor.cs
+++ b/src/Carbon/Modules/AdminModule/AdminModule.Tabs.ConfigEditor.cs
@@ -14,9 +14,15 @@ public partial class AdminModule
 		internal Action<PlayerSession, JObject> OnSave, OnSaveAndReload, OnCancel;
 		internal const string Spacing = " ";
 		internal string[] Blacklist;
+		internal Dictionary<string, int> LegendIndex;
+		internal Dictionary<string, string[]> LegendOptions;
+		internal Dictionary<string, JToken[]> LegendValues;
 
 		public ConfigEditor(string id, string name, RustPlugin plugin, Action<PlayerSession, Tab> onChange = null) : base(id, name, plugin, onChange)
 		{
+			LegendIndex = Facepunch.Pool.Get<Dictionary<string, int>>();
+			LegendOptions = Facepunch.Pool.Get<Dictionary<string, string[]>>();
+			LegendValues = Facepunch.Pool.Get<Dictionary<string, JToken[]>>();
 		}
 
 		public static ConfigEditor Make(string json, Action<PlayerSession, JObject> onCancel, Action<PlayerSession, JObject> onSave, Action<PlayerSession, JObject> onSaveAndReload, bool fullscreen = false, string[] blacklist = null)
@@ -47,9 +53,63 @@ public partial class AdminModule
 			AddButtonArray(-1, list.ToArray());
 			Facepunch.Pool.FreeUnmanaged(ref list);
 
+			void createLegendMap(JObject inner)
+			{
+				foreach (var token in inner)
+				{
+					if (token.Value is JObject legendObj)
+					{
+						if (token.Key.EndsWith("Legend"))
+						{
+							LegendOptions[token.Key] = [.. legendObj.Properties().Select(x => x.Name)];
+							LegendValues[token.Key] = [.. legendObj.Properties().Select(x => x.Value)];
+						}
+
+						createLegendMap(legendObj);
+					}
+				}
+			}
+
+			void populateDefaultIndexes(JObject inner)
+			{
+				if (LegendOptions.Count == 0)
+					return;
+
+				foreach (var token in inner)
+				{
+					if (token.Value is JObject jObj)
+						populateDefaultIndexes(jObj);
+
+					var legendKey = token.Key.Trim() + "Legend";
+					if (LegendValues.TryGetValue(legendKey, out var values))
+					{
+						var idx = values.IndexOf(token.Value);
+						LegendIndex[legendKey] = Math.Max(0, idx);
+					}
+				}
+			}
+
+			createLegendMap(Entry);
+			populateDefaultIndexes(Entry);
+
+			for (int i = LegendOptions.Count - 1; i >= 0; i--)
+			{
+				var legend = LegendOptions.ElementAt(i);
+				if (!LegendIndex.ContainsKey(legend.Key))
+				{
+					LegendOptions.Remove(legend.Key);
+					LegendValues.Remove(legend.Key);
+				}
+			}
+
 			foreach (var token in Entry)
 			{
-				if (token.Value is JObject) AddName(0, $"{token.Key}");
+				if (token.Value is JObject)
+				{
+					var trimKey = token.Key.Trim();
+					if (LegendOptions.Count == 0 || !trimKey.EndsWith("Legend") || !LegendOptions.ContainsKey(trimKey))
+						AddName(0, $"{token.Key}");
+				}
 
 				_recurseBuild(token.Key, token.Value, 0, 0);
 			}
@@ -60,6 +120,10 @@ public partial class AdminModule
 			{
 				return;
 			}
+
+			var trimName = name.Trim();
+			if (LegendOptions.Count > 0 && LegendOptions.ContainsKey(trimName + "Legend"))
+				return;
 
 			switch (token)
 			{
@@ -120,22 +184,39 @@ public partial class AdminModule
 							break;
 
 						case JTokenType.Object:
-							var newLevel = level + 1;
-							if (token.Parent is JArray array)
+							if (LegendIndex.Count > 0 && LegendOptions.Count > 0
+								&& LegendIndex.TryGetValue(trimName, out var idx)
+								&& LegendOptions.TryGetValue(trimName, out var options)
+								&& LegendValues.TryGetValue(trimName, out var values))
 							{
-								AddInputButton(column, null, 0.2f,
-									new OptionInput(null, ap => $"{array.IndexOf(token)}", 0, true, null),
-									new OptionButton("Remove", TextAnchor.MiddleCenter, ap =>
+								var baseName = trimName[..^"Legend".Length];
+								AddDropdown(column, baseName,
+									ap => Math.Max(0, LegendIndex[trimName]),
+									(ap, i) =>
 									{
-										array.Remove(token);
-										ClearColumn(column);
-										// DrawArray(name, array, 0, true);
-										_drawArray(name, array, level, column, ap);
-									}, ap => OptionButton.Types.Important));
-
+										LegendIndex[trimName] = i;
+										var entry = token.Parent[baseName] is JProperty property ? property.Value : token.Parent[baseName];
+										entry.Replace(entry = values[i]);
+									}, options, tooltip: $"The selected value of the '{baseName}' property.");
 							}
-							DrawArray(name, token, newLevel);
+							else
+							{
+								var newLevel = level + 1;
+								if (token.Parent is JArray array)
+								{
+									AddInputButton(column, null, 0.2f,
+										new OptionInput(null, ap => $"{array.IndexOf(token)}", 0, true, null),
+										new OptionButton("Remove", TextAnchor.MiddleCenter, ap =>
+										{
+											array.Remove(token);
+											ClearColumn(column);
+											// DrawArray(name, array, 0, true);
+											_drawArray(name, array, level, column, ap);
+										}, ap => OptionButton.Types.Important));
 
+								}
+								DrawArray(name, token, newLevel);
+							}
 							break;
 					}
 					break;
@@ -214,6 +295,15 @@ public partial class AdminModule
 					_drawArray(name, array, level, column, ap);
 				}, ap2 => OptionButton.Types.Selected);
 			}
+		}
+
+		public override void Dispose()
+		{
+			base.Dispose();
+
+			Facepunch.Pool.FreeUnmanaged(ref LegendIndex);
+			Facepunch.Pool.FreeUnmanaged(ref LegendOptions);
+			Facepunch.Pool.FreeUnmanaged(ref LegendValues);
 		}
 	}
 }

--- a/src/Carbon/Modules/AdminModule/AdminModule.Tabs.ConfigEditor.cs
+++ b/src/Carbon/Modules/AdminModule/AdminModule.Tabs.ConfigEditor.cs
@@ -14,15 +14,15 @@ public partial class AdminModule
 		internal Action<PlayerSession, JObject> OnSave, OnSaveAndReload, OnCancel;
 		internal const string Spacing = " ";
 		internal string[] Blacklist;
+
+		const string LegendSuffix = "Legend";
 		internal Dictionary<string, int> LegendIndex;
 		internal Dictionary<string, string[]> LegendOptions;
-		internal Dictionary<string, JToken[]> LegendValues;
 
 		public ConfigEditor(string id, string name, RustPlugin plugin, Action<PlayerSession, Tab> onChange = null) : base(id, name, plugin, onChange)
 		{
 			LegendIndex = Facepunch.Pool.Get<Dictionary<string, int>>();
 			LegendOptions = Facepunch.Pool.Get<Dictionary<string, string[]>>();
-			LegendValues = Facepunch.Pool.Get<Dictionary<string, JToken[]>>();
 		}
 
 		public static ConfigEditor Make(string json, Action<PlayerSession, JObject> onCancel, Action<PlayerSession, JObject> onSave, Action<PlayerSession, JObject> onSaveAndReload, bool fullscreen = false, string[] blacklist = null)
@@ -57,57 +57,41 @@ public partial class AdminModule
 			{
 				foreach (var token in inner)
 				{
-					if (token.Value is JObject legendObj)
+					if (token.Value is not JObject legendObj)
+						continue;
+
+					if (token.Key.EndsWith(LegendSuffix))
 					{
-						if (token.Key.EndsWith("Legend"))
+						var baseName = token.Key[..^LegendSuffix.Length].Trim();
+						var baseToken = legendObj.Parent?.Parent?[baseName];
+
+						if (baseToken != null)
 						{
-							LegendOptions[token.Key] = [.. legendObj.Properties().Select(x => x.Name)];
-							LegendValues[token.Key] = [.. legendObj.Properties().Select(x => x.Value)];
+							LegendOptions[token.Key] = [.. legendObj.Properties().Select(p => p.Name)];
+
+							var baseTokenValue = baseToken.ToString();
+							var defaultValue = legendObj.Properties()
+								.FirstOrDefault(p => p.Name == baseTokenValue)
+								?? legendObj.Properties().First();
+
+							LegendIndex[token.Key] = legendObj.Properties().IndexOf(defaultValue);
+
+							continue;
 						}
-
-						createLegendMap(legendObj);
 					}
-				}
-			}
 
-			void populateDefaultIndexes(JObject inner)
-			{
-				if (LegendOptions.Count == 0)
-					return;
-
-				foreach (var token in inner)
-				{
-					if (token.Value is JObject jObj)
-						populateDefaultIndexes(jObj);
-
-					var legendKey = token.Key.Trim() + "Legend";
-					if (LegendValues.TryGetValue(legendKey, out var values))
-					{
-						var idx = values.IndexOf(token.Value);
-						LegendIndex[legendKey] = Math.Max(0, idx);
-					}
+					createLegendMap(legendObj);
 				}
 			}
 
 			createLegendMap(Entry);
-			populateDefaultIndexes(Entry);
-
-			for (int i = LegendOptions.Count - 1; i >= 0; i--)
-			{
-				var legend = LegendOptions.ElementAt(i);
-				if (!LegendIndex.ContainsKey(legend.Key))
-				{
-					LegendOptions.Remove(legend.Key);
-					LegendValues.Remove(legend.Key);
-				}
-			}
 
 			foreach (var token in Entry)
 			{
 				if (token.Value is JObject)
 				{
 					var trimKey = token.Key.Trim();
-					if (LegendOptions.Count == 0 || !trimKey.EndsWith("Legend") || !LegendOptions.ContainsKey(trimKey))
+					if (LegendOptions.Count == 0 || !trimKey.EndsWith(LegendSuffix) || !LegendOptions.ContainsKey(trimKey))
 						AddName(0, $"{token.Key}");
 				}
 
@@ -122,7 +106,7 @@ public partial class AdminModule
 			}
 
 			var trimName = name.Trim();
-			if (LegendOptions.Count > 0 && LegendOptions.ContainsKey(trimName + "Legend"))
+			if (LegendOptions.Count > 0 && LegendOptions.ContainsKey(trimName + LegendSuffix))
 				return;
 
 			switch (token)
@@ -187,17 +171,27 @@ public partial class AdminModule
 							if (LegendIndex.Count > 0 && LegendOptions.Count > 0
 								&& LegendIndex.TryGetValue(trimName, out var idx)
 								&& LegendOptions.TryGetValue(trimName, out var options)
-								&& LegendValues.TryGetValue(trimName, out var values))
+								&& usableToken is JObject tokenObject)
 							{
-								var baseName = trimName[..^"Legend".Length];
+								var baseName = trimName[..^LegendSuffix.Length];
+
 								AddDropdown(column, baseName,
-									ap => Math.Max(0, LegendIndex[trimName]),
+									ap => Mathf.Clamp(LegendIndex[trimName], 0, options.Length - 1),
 									(ap, i) =>
 									{
+										var baseToken = tokenObject.Parent?.Parent?[baseName];
+										if (baseToken == null)
+										{
+											// This is already handled and we shouldn't get here. Something in the config must have changed.
+											throw new InvalidOperationException($"Failed to find token for '{baseToken}', please validate configuration and try again.");
+										}
+
+										var newValue = tokenObject.Properties().ElementAt(i).Value;
+										baseToken.Replace(newValue);
+
 										LegendIndex[trimName] = i;
-										var entry = token.Parent[baseName] is JProperty property ? property.Value : token.Parent[baseName];
-										entry.Replace(entry = values[i]);
-									}, options, tooltip: $"The selected value of the '{baseName}' property.");
+									},
+									options, tooltip: $"The selected value of the '{baseName}' property.");
 							}
 							else
 							{
@@ -303,7 +297,6 @@ public partial class AdminModule
 
 			Facepunch.Pool.FreeUnmanaged(ref LegendIndex);
 			Facepunch.Pool.FreeUnmanaged(ref LegendOptions);
-			Facepunch.Pool.FreeUnmanaged(ref LegendValues);
 		}
 	}
 }


### PR DESCRIPTION
This change allows plugin authors to create Dictionary<string, TValue> properties with "Legend" suffixes, where the key is the string descriptor and the value is what will be set in the matching config variable.

"Legend"-suffixed properties must have a matching non-"Legend" property, or it gets ignored.
The selected item defaults to the non-"Legend" property's default value, or the first option if it could not find a match in the available options.

Example usage:
```csharp
            /// <summary>
            /// List of data formats that can be used to save the snapshot data.
            /// </summary>
            [JsonProperty("Data Save FormatLegend")]
            public Dictionary<string, DataFormat> DataSaveFormatLegend => _dataFormatLegend;
            private static readonly Dictionary<string, DataFormat> _dataFormatLegend = new()
            {
                ["Binary"] = DataFormat.Binary,
                ["Binary (GZip Compressed)"] = DataFormat.GZip,
                ["Json"] = DataFormat.Json,
                ["Json (Expanded)"] = DataFormat.JsonExpanded
            };

            /// <summary>
            /// The type to use when saving the snapshot data.
            /// </summary>
            [JsonProperty("Data Save Format")]
            public DataFormat DataSaveFormat { get; set; } = DataFormat.GZip;
```

Menu Result:

![image](https://github.com/user-attachments/assets/aea33dc4-fd79-4e41-9eab-0043d56677b7)

Config Result:
```json
{
  "Advanced Settings (Caution: Changes may cause lag)": {
    "Data Save FormatLegend": {
      "Binary": 0,
      "Binary (GZip Compressed)": 1,
      "Json": 2,
      "Json (Expanded)": 3
    },
    "Data Save Format": 1
  }
}
```