### PR TITLE
feat: -carbon.settingdir for override dir with Carbon config file

### DIFF
--- a/src/Carbon/Components/Switches.cs
+++ b/src/Carbon/Components/Switches.cs
@@ -5,6 +5,9 @@ public sealed class Switches
 	[Switch(Name = "-carbon.rootdir", Help = "Overrides the root directory of Carbon, aka the \"carbon\" folder. Upon changing this, you must also apply another command line variable which links to the custom Carbon root, Carbon.Preloader.dll;\n--doorstop-target-assembly \"customrootdir/managed/Carbon.Preloader.dll\"")]
 	public static string GetRootDir(string defaultValue = null) => CommandLineEx.GetArgumentResult("-carbon.rootdir", defaultValue);
 
+	[Switch(Name = "-carbon.settingdir", Help = "Overrides the settings root directory where Carbon stores its configuration files")]
+	public static string GetSettingDir(string defaultValue = null) => CommandLineEx.GetArgumentResult("-carbon.settingdir", defaultValue);
+	
 	[Switch(Name = "-carbon.scriptdir", Help = "Overrides the scripts directory of Carbon, aka the \"carbon/plugins\" folder.")]
 	public static string GetScriptDir(string defaultValue = null) => CommandLineEx.GetArgumentResult("-carbon.scriptdir", defaultValue);
 


### PR DESCRIPTION
# Description
For now, we cannot move config file of Carbon, but I suggest add new switch `-carbon.settingdir` which override default <root> dir for Carbon Config, Carbon Auto and Carbon Profiler configs

# Example of use

1) Push config file to server Git (if exists) and easily use it
2) Centralized config file (ex. /opt/carbon/config) for reusing on production servers

# Affect 

This feature affects theese repo:


[CarbonCommunity/Carbon.Preloader](https://github.com/CarbonCommunity/Carbon.Preloader)


[CarbonCommunity/Carbon.Bootstrap](https://github.com/CarbonCommunity/Carbon.Bootstrap)


[CarbonCommunity/Carbon.Startup](https://github.com/CarbonCommunity/Carbon.Startup)

[CarbonCommunity/Carbon.Common](https://github.com/CarbonCommunity/Carbon.Common)