### PR TITLE
Fixed RawImageComp png remains set when taken from pool

### DIFF
--- a/src/Carbon/Components/LUI.cs
+++ b/src/Carbon/Components/LUI.cs
@@ -2003,6 +2003,7 @@ public static class LuiPool
 		comp.color = null;
 		comp.material = null;
 		comp.url = null;
+		comp.png = null;
 		comp.steamid = null;
 		comp.fadeIn = 0;
 		return comp;


### PR DESCRIPTION
I have found another issue where the png property of the rawimage remains set. 
Which leads to unwanted images being displayed.