### PR TITLE
Fix for RPCError when using CuiContentSizeFitterComponent

### DIFF
--- a/src/Oxide/CUI/CuiCore.cs
+++ b/src/Oxide/CUI/CuiCore.cs
@@ -694,9 +694,11 @@ public class CuiContentSizeFitterComponent : ICuiComponent, ICuiEnableable
 {
 	public string Type => "UnityEngine.UI.ContentSizeFitter";
 
+	[JsonConverter(typeof(StringEnumConverter))]
 	[JsonProperty("horizontalFit")]
 	public ContentSizeFitter.FitMode HorizontalFit { get; set; }
 
+	[JsonConverter(typeof(StringEnumConverter))]
 	[JsonProperty("verticalFit")]
 	public ContentSizeFitter.FitMode VerticalFit { get; set; }
 


### PR DESCRIPTION
Added `StringEnumConverter` for `CuiContentSizeFitterComponent.HorizontalFit` and `CuiContentSizeFitterComponent.VerticalFit`