### PR TITLE
Rename `DISABLED` into `ENABLE VIA COG` when umod tab is disabled

### DIFF
--- a/src/Carbon/Modules/AdminModule/AdminModule.Tabs.Plugins.cs
+++ b/src/Carbon/Modules/AdminModule/AdminModule.Tabs.Plugins.cs
@@ -73,7 +73,7 @@ public partial class AdminModule
 			"banan",
 			"peanus"
 		];
-		
+
 		public static Tab TabInstance;
 
 		public static Vendor CodeflingInstance;
@@ -149,7 +149,7 @@ public partial class AdminModule
 
 							if (disabled)
 							{
-								cui.CreateText(container, btn, "1 0.8 0.8 0.5", "DISABLED", 10, yMax: 0.5f);
+								cui.CreateText(container, btn, "1 0.8 0.8 0.5", "ENABLE VIA COG", 10, yMax: 0.5f);
 							}
 
 							optionsOffset += optionsWidth + optionsSpacing;


### PR DESCRIPTION
It is not intuitive for a user that it can be enabled via settings.

### Before

<img width="403" height="158" alt="25-10-25_18-12-26" src="https://github.com/user-attachments/assets/03a08c5e-9cab-415c-ba8a-f558870d661c" />

### After

<img width="476" height="174" alt="25-10-25_18-07-30" src="https://github.com/user-attachments/assets/66b7a536-8783-4b2b-92d0-4aac5fe7a133" />
